### PR TITLE
Added user agent for Azure Traffic Manager and Azure AppService AlwaysOn crawlers

### DIFF
--- a/src/Presentation/Nop.Web/App_Data/browscap.crawlersonly.xml
+++ b/src/Presentation/Nop.Web/App_Data/browscap.crawlersonly.xml
@@ -14004,4 +14004,10 @@
   <browscapitem name="Core_Class_HttpClient_Cached">
     <item name="Crawler" value="true" />
   </browscapitem>
+  <browscapitem name="Azure Traffic Manager Endpoint Monitor"> <!-- Azure Traffic Manager -->
+    <item name="Crawler" value="true" />
+  </browscapitem>
+  <browscapitem name="AlwaysOn"> <!-- Azure AppService AlwaysOn -->
+    <item name="Crawler" value="true" />
+  </browscapitem>
 </browsercapitems>


### PR DESCRIPTION
### Azure Traffic Manager

When using [Azure Traffic Manager endpoint monitoring](https://docs.microsoft.com/en-us/azure/traffic-manager/traffic-manager-monitoring), set the Path to `/keepalive` instead of `/` to avoid creating a guest Customer every time the traffic manager calls the url. Another solution is to add Traffic Manager as a crawler:

```xml
<browscapitem name="Azure Traffic Manager Endpoint Monitor"> <!-- Azure Traffic Manager -->
  <item name="Crawler" value="true" />
</browscapitem>
```

### Azure App Service Always On

When using [Azure App Service Always On](https://docs.microsoft.com/en-us/azure/app-service/configure-common?tabs=portal#configure-general-settings) functionality, it  will call the root url every 5 minutes, which can create a guest Customer on each request. This can be disabled by configuring the `Always On` User Agent as a crawler:

```xml
<browscapitem name="AlwaysOn"> <!-- Azure AppService AlwaysOn -->
  <item name="Crawler" value="true" />
</browscapitem>
```